### PR TITLE
Configured application.properties to load in env.properties

### DIFF
--- a/bigger-shape-api/.gitignore
+++ b/bigger-shape-api/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Environment variables ###
+env.properties

--- a/bigger-shape-api/src/main/resources/application.properties
+++ b/bigger-shape-api/src/main/resources/application.properties
@@ -1,1 +1,15 @@
+# Load in environment variables
+spring.config.import=optional:file:env.properties
+
 spring.application.name=bigger-shape-api
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=none
+
+# Server configuration
+server-port=8080
+
+# API configuration
+api.endpoint=/api/v1
+
+


### PR DESCRIPTION
Note that you will need to add the file `env.properties` to the root directory of the Spring application (this is NOT the root directory of the whole project - this is within the directory `bigger-shape-api`).