### PR TITLE
changed survey to use end point, fixed cors issue

### DIFF
--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/controllers/QuestionnaireController.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/controllers/QuestionnaireController.java
@@ -7,13 +7,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import bigger.shape.bigger_shape_api.responses.GetQuestionsResponse;
 import bigger.shape.bigger_shape_api.services.QuestionnaireService;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:5173")
 /**
  * MIGHT HAVE TO PUT CORS HERE - not sure about it
  * 
  * @CrossOrigin(origins = "http://localhost:_____")
  */
+
 @RequestMapping("/api/v1")
 public class QuestionnaireController {
   private final QuestionnaireService questionnaireService;
@@ -26,6 +29,7 @@ public class QuestionnaireController {
    * Endpoint to get all questions from the questionnaire.
    * 
    * Test on: "http://localhost:8080/api/v1/public/questions"
+   * 
    * @return ResponseEntity containing GetQuestionsResponse with all questions.
    */
   @GetMapping("/public/questions")

--- a/bigger-shape-web/src/components/Survey.tsx
+++ b/bigger-shape-web/src/components/Survey.tsx
@@ -201,7 +201,7 @@ function Survey() {
   const [page, setPage] = useState(0);
 
   useEffect(() => {
-    fetch('/response_forTesting.json')
+    fetch('http://localhost:8080/api/v1/public/questions')
       .then(res => res.json())
       .then(data => {
         console.log("Fetched data:", data);  // This should log your JSON object


### PR DESCRIPTION
Survey now uses api endpoint to get questions, the cors fix is hacky but works for now.

To test: run spring on backend while you launch frontend and then go to survey page. Survey page should now display questions.