### PR TITLE
JWT Validation on Get Request to User Questionnaire History

### DIFF
--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/configurations/SecurityConfig.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/configurations/SecurityConfig.java
@@ -1,5 +1,7 @@
 package bigger.shape.bigger_shape_api.configurations;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,6 +9,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import bigger.shape.bigger_shape_api.filters.JwtAuthenticationFilter;
 import bigger.shape.bigger_shape_api.services.JwtVerifierService;
@@ -21,6 +26,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/public/**").permitAll()
@@ -29,5 +35,18 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("http://localhost:5173");
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/controllers/UserController.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/controllers/UserController.java
@@ -1,5 +1,6 @@
 package bigger.shape.bigger_shape_api.controllers;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -37,6 +38,15 @@ public class UserController {
                 "userId", claims.get("sub"),
                 "email", claims.get("email"),
                 "role", claims.get("role"));
+    }
+
+    @GetMapping("/users/history")
+    public List<QuestionnaireHistoryEntryDto> getUserQuestionnaireHistory(Authentication authentication) {
+        // Get subject from authentication
+        Claims claims = (Claims) authentication.getPrincipal();
+        UUID id = UUID.fromString(claims.getSubject());
+
+        return userService.findAllQuestionnaireHistoryEntries(id);
     }
 
     /**

--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/dtos/AnswerDto.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/dtos/AnswerDto.java
@@ -1,9 +1,17 @@
 package bigger.shape.bigger_shape_api.dtos;
 
+import bigger.shape.bigger_shape_api.entities.Answer;
 import lombok.Data;
 
 @Data
 public class AnswerDto {
     private String answerContent;
     private Long questionOrder;
+
+    public static AnswerDto fromEntity(Answer answer) {
+        AnswerDto result = new AnswerDto();
+        result.setAnswerContent(answer.getAnswerContent());
+        result.setQuestionOrder(answer.getQuestion().getOrder());
+        return result;
+    }
 }

--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/repositories/AnswerRepository.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/repositories/AnswerRepository.java
@@ -1,9 +1,23 @@
 package bigger.shape.bigger_shape_api.repositories;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import bigger.shape.bigger_shape_api.entities.Answer;
 import bigger.shape.bigger_shape_api.entities.AnswerId;
 
 public interface AnswerRepository extends JpaRepository<Answer, AnswerId> {
+
+    @Query("""
+            SELECT a FROM Answer a
+                JOIN a.questionnaireResult qr
+            WHERE qr.user.id = :userId AND qr.dateTaken = :dateTaken AND qr.riskScore = :riskScore
+            """)
+    public List<Answer> findAllAnswersByIdDateScore(@Param("userId") UUID userId,
+            @Param("dateTaken") OffsetDateTime dateTaken, @Param("riskScore") String riskScore);
 }

--- a/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/services/UserService.java
+++ b/bigger-shape-api/src/main/java/bigger/shape/bigger_shape_api/services/UserService.java
@@ -2,11 +2,13 @@ package bigger.shape.bigger_shape_api.services;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
 import bigger.shape.bigger_shape_api.dtos.AnswerDto;
 import bigger.shape.bigger_shape_api.dtos.QuestionnaireHistoryEntryDto;
+import bigger.shape.bigger_shape_api.dtos.QuestionnaireResultDto;
 import bigger.shape.bigger_shape_api.entities.Answer;
 import bigger.shape.bigger_shape_api.entities.AnswerId;
 import bigger.shape.bigger_shape_api.entities.QuestionnaireResult;
@@ -33,11 +35,30 @@ public class UserService {
         this.questionRepository = questionRepository;
     }
 
-    public List<QuestionnaireHistoryEntryDto> getQuestionnaireHistory(UUID id) {
+    public List<QuestionnaireHistoryEntryDto> findAllQuestionnaireHistoryEntries(UUID id) {
+        // Check if the user exists
+        userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        // Get all of the quesionnaire results
         List<QuestionnaireResult> history = questionnaireRepository.findAllQuestionnaireResultsById(id);
+
+        // Process each result: map into a DTO, add all Answers, and collect
         return history.stream()
                 .map(QuestionnaireHistoryEntryDto::fromQuestionnaireResultEntity)
-                .toList();
+                .peek(entry -> {
+                    // Get the quesionnaire DTO
+                    QuestionnaireResultDto dto = entry.getQuestionnaire();
+
+                    // Retrieve answers as a DTO
+                    List<AnswerDto> answers = answerRepository
+                            .findAllAnswersByIdDateScore(id, dto.getDateTaken(), dto.getRiskScore()).stream()
+                            .map(AnswerDto::fromEntity).collect(Collectors.toList());
+
+                    // Add all answers for this entry
+                    entry.getAnswers().addAll(answers);
+                })
+                .collect(Collectors.toList());
+
     }
 
     @Transactional


### PR DESCRIPTION
## Repositories
- Implemented `findAllAnswersByIdDateScore` method within `AnswerRepository` to retrieve all answers of a questionnaire.

## UserService
- Implemented `findAllQuestionnaireHistoryEntries` that takes in the `UUID` of a user (extracted from the JWT).
- Utilizes streams to process collections of elements, namely `QuestionnaireResult`, `QuestionnaireHistoryEntryDto`, `Answer`, and `AnswerDto` objects.

## UserController
- Implemented `GET` request on `.../auth/users/history`.
- Simply providing the `Authentication` header will automatically extract the subject claim from the token and query for the given user.