### PR TITLE
Implemented basic login using email and password

### DIFF
--- a/bigger-shape-web/src/Button.tsx
+++ b/bigger-shape-web/src/Button.tsx
@@ -3,7 +3,7 @@ import React from "react";
 interface ButtonProps {
   type: "button" | "submit";
   color: string;
-  onClick: () => void;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
   text: string;
   imagePath?: string;
   altText?: string;

--- a/bigger-shape-web/src/LoginPage.tsx
+++ b/bigger-shape-web/src/LoginPage.tsx
@@ -5,8 +5,6 @@ import { useNavigate } from "react-router-dom";
 import { useAuth, supabase } from "./AuthContext";
 
 const LoginPage = () => {
-  const handleSubmit = () => {};
-
   const navigate = useNavigate();
   const auth = useAuth();
 
@@ -24,6 +22,24 @@ const LoginPage = () => {
     document.title = "Log Into SHAPE";
   }, []);
 
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState(false);
+
+  // Login using email and password
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: email,
+      password: password,
+    });
+    if (error) {
+      setLoginError(true); // dynamically renders error message
+    }
+    // If successful, useEffect detects the change in auth and redirects user to /dashboard
+  };
+
+  // Hands OAuth login via Google
   const handleGoogleLogin = async () => {
     setOAuthError(false); // reset
     const { error } = await supabase.auth.signInWithOAuth({
@@ -74,6 +90,7 @@ const LoginPage = () => {
               width={5}
               height={4}
               altText="Mail"
+              onChange={(e) => setEmail(e.target.value)}
             />
             <Input
               type="password"
@@ -83,13 +100,19 @@ const LoginPage = () => {
               width={5}
               height={5}
               altText="Lock"
+              onChange={(e) => setPassword(e.target.value)}
             />
             <Button
               type="submit"
               color="green"
               text="Sign In"
-              onClick={handleSubmit}
+              onClick={(e) => handleSubmit(e)}
             />
+            {loginError && (
+              <p className="text-red-600 font-bold">
+                Incorrect username or password.
+              </p>
+            )}
           </form>
           <div className="flex items-center my-4">
             <hr className="flex-grow border-t border-black" />
@@ -127,6 +150,7 @@ interface InputProps {
   width: number;
   height: number;
   altText: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const Input: React.FC<InputProps> = ({
@@ -137,6 +161,7 @@ const Input: React.FC<InputProps> = ({
   width,
   height,
   altText,
+  onChange,
 }) => {
   const inputClass =
     "pl-12 w-full rounded py-2 border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-400";
@@ -154,7 +179,13 @@ const Input: React.FC<InputProps> = ({
           />
           <div className="h-10 w-0.5 bg-gray-300 ml-2" />
         </span>
-        <input type={type} id={id} className={inputClass} required />
+        <input
+          type={type}
+          id={id}
+          className={inputClass}
+          onChange={onChange}
+          required
+        />
       </div>
     </>
   );

--- a/bigger-shape-web/src/components/InputField.tsx
+++ b/bigger-shape-web/src/components/InputField.tsx
@@ -1,29 +1,44 @@
-function InputField({ type, id, label, options, requiredField, regex, setIsValidInput, sizeRange, setIsValidLength, setCurrentValue, currentValue }) {
+function InputField({
+  type,
+  id,
+  label,
+  options,
+  requiredField,
+  regex,
+  setIsValidInput,
+  sizeRange,
+  setIsValidLength,
+  setCurrentValue,
+  currentValue,
+}) {
   function checkInput(event) {
     if (sizeRange) {
-      if (event.target.value.length < sizeRange.min || event.target.value.length > sizeRange.max) {
-        setIsValidLength(prevState => ({
+      if (
+        event.target.value.length < sizeRange.min ||
+        event.target.value.length > sizeRange.max
+      ) {
+        setIsValidLength((prevState) => ({
           ...prevState,
-          [id]: false
+          [id]: false,
         }));
       } else {
-        setIsValidLength(prevState => ({
+        setIsValidLength((prevState) => ({
           ...prevState,
-          [id]: true
+          [id]: true,
         }));
       }
     }
     // console.log("keyup");
     const value = event.target.value;
     if (!requiredField && value === "") {
-      setIsValidInput(prevState => ({
+      setIsValidInput((prevState) => ({
         ...prevState,
-        [id]: true
+        [id]: true,
       }));
     } else if (regex) {
-      setIsValidInput(prevState => ({
+      setIsValidInput((prevState) => ({
         ...prevState,
-        [id]: regex.test(value)
+        [id]: regex.test(value),
       }));
     }
   }
@@ -32,29 +47,48 @@ function InputField({ type, id, label, options, requiredField, regex, setIsValid
     setCurrentValue(event.target.value);
   }
 
-  const labelClass = 'text-left pb-[2vh]';
+  const labelClass = "text-left pb-[2vh]";
   // console.log(type, id, label, options);
   switch (type.toLowerCase()) {
-    case 'text':
-    case 'password':
+    case "text":
+    case "password":
       return (
         <div className="flex mt-[2vh]">
-          <label htmlFor={id} className="pr-[1vh] text-white min-w-[10vw]">{label}</label>
-          <input type={type} id={id} name={id} className="bg-white rounded text-center" required={requiredField} onChange={(e) => {
-            checkInput(e);
-            updateCurrentValue(e);
-          }}></input><p><span className="ml-2 text-red-600">{requiredField ? "*" : " "}</span></p>
+          <label htmlFor={id} className="pr-[1vh] text-white min-w-[10vw]">
+            {label}
+          </label>
+          <input
+            type={type}
+            id={id}
+            name={id}
+            className="bg-white rounded text-center"
+            required={requiredField}
+            onChange={(e) => {
+              checkInput(e);
+              updateCurrentValue(e);
+            }}
+          ></input>
+          <p>
+            <span className="ml-2 text-red-600">
+              {requiredField ? "*" : " "}
+            </span>
+          </p>
           <br></br>
-        </div >
+        </div>
       );
-    case 'select':
+    case "select":
       if (options === null || label === null) {
         return null;
       }
       return (
         <>
           <label className={labelClass}>{label}</label>
-          <select id={id} className="bg-white" onChange={updateCurrentValue} value={currentValue || "default"}>
+          <select
+            id={id}
+            className="bg-white"
+            onChange={updateCurrentValue}
+            value={currentValue || "default"}
+          >
             <option value="default" disabled>
               Select Option
             </option>


### PR DESCRIPTION
Test the following:
If the incorrect username and password is entered, an error message should display.
Upon successful login, the user should be redirected to /dashboard. The profile picture will be default man, but display name and email will appear.
Logging out should redirect to /login and manually navigating to /dashboard should hide authenticated components and text.